### PR TITLE
Fix 'await' bug in local REPL sessions

### DIFF
--- a/DIR_STRUCTURE.md
+++ b/DIR_STRUCTURE.md
@@ -49,7 +49,7 @@
 │       │   │   │   ├── [L: 151] builder.py
 │       │   │   │   ├── [L:  29] events.py
 │       │   │   │   ├── [L: 712] graph.py
-│       │   │   │   └── [L:  65] step.py
+│       │   │   │   └── [L:  59] step.py
 │       │   │   ├── [L: 562] history.py
 │       │   │   ├── [L: 109] policies.py
 │       │   │   ├── terminal/
@@ -93,7 +93,7 @@
 │       │   │   │   ├── [L: 227] adapters.py
 │       │   │   │   ├── [L:  38] cli.py
 │       │   │   │   ├── commands/
-│       │   │   │   ├── [L: 830] core.py
+│       │   │   │   ├── [L: 841] core.py
 │       │   │   │   ├── [L:  83] display.py
 │       │   │   │   ├── [L:  83] file_runner.py
 │       │   │   │   └── [L:  15] state.py
@@ -196,4 +196,4 @@
     └── transport/
         └── [L:   1] __init__.py
 
-42 directories, 155 files, 33,209 total lines
+42 directories, 155 files, 33,214 total lines


### PR DESCRIPTION
- ensure that code containing 'await' is properly wrapped and awaited in local mode
- merge async function locals back into REPL namespace for session consistency
- clean up temporary async function after execution
- minor doc and comment adjustments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced async/await code handling in the REPL for both local and server modes, ensuring variables defined within async contexts are properly captured and persisted in the session namespace.

* **Chores**
  * Updated directory structure documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->