### PR TITLE
Add OpenRouterNode and GLMNode for ephemeral LLM API calls

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,1 @@
+.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .nerve
 .venv/
 .envrc.local
+.env.local
 bin/
 anthropicLogs/

--- a/DIR_STRUCTURE.md
+++ b/DIR_STRUCTURE.md
@@ -44,8 +44,15 @@
 │   │   ├── [L:  54] client.py
 │   │   └── [L:  40] server.py
 │   └── [L:  32] sample_graph.py
-├── [L:  24] Makefile
-├── [L:  89] pyproject.toml
+├── features/
+│   ├── glm/
+│   │   ├── [L: 214] glm_chat_node.py
+│   │   └── [L: 133] glm_node.py
+│   └── openrouter/
+│       ├── [L: 223] openrouter_chat_node.py
+│       └── [L: 162] openrouter_node.py
+├── [L:  36] Makefile
+├── [L:  93] pyproject.toml
 ├── [L:   1] README.md
 ├── scripts/
 │   ├── [L:  52] bump.py
@@ -61,7 +68,7 @@
 │   │   │   ├── [L:  67] models.py
 │   │   │   ├── [L: 149] parsing.py
 │   │   │   └── [L:  98] themes.py
-│   │   └── [L:1195] summarize_session.py
+│   │   └── [L:1199] summarize_session.py
 │   ├── [L:  85] run_anthropic_passthrough.py
 │   └── [L:  58] run_openai_proxy.py
 ├── src/
@@ -72,7 +79,7 @@
 │       ├── core/
 │       │   ├── [L: 178] __init__.py
 │       │   ├── nodes/
-│       │   │   ├── [L: 143] __init__.py
+│       │   │   ├── [L: 148] __init__.py
 │       │   │   ├── [L: 270] base.py
 │       │   │   ├── [L: 271] bash.py
 │       │   │   ├── [L: 190] budget.py
@@ -85,6 +92,12 @@
 │       │   │   │   ├── [L: 712] graph.py
 │       │   │   │   └── [L:  59] step.py
 │       │   │   ├── [L: 562] history.py
+│       │   │   ├── llm/
+│       │   │   │   ├── [L:  68] __init__.py
+│       │   │   │   ├── [L: 575] base.py
+│       │   │   │   ├── [L: 392] chat.py
+│       │   │   │   ├── [L: 135] glm.py
+│       │   │   │   └── [L: 105] openrouter.py
 │       │   │   ├── [L: 109] policies.py
 │       │   │   ├── terminal/
 │       │   │   │   ├── [L:  24] __init__.py
@@ -129,15 +142,15 @@
 │       │   │   │   ├── [L: 139] cleanup.py
 │       │   │   │   ├── [L:  38] cli.py
 │       │   │   │   ├── commands/
-│       │   │   │   ├── [L: 340] core.py
+│       │   │   │   ├── [L: 342] core.py
 │       │   │   │   ├── [L:  83] display.py
-│       │   │   │   ├── [L:  83] file_runner.py
+│       │   │   │   ├── [L:  85] file_runner.py
 │       │   │   │   ├── [L: 486] registry.py
 │       │   │   │   └── [L:  15] state.py
 │       │   │   ├── server/
 │       │   │   │   ├── [L: 548] __init__.py
 │       │   │   │   ├── [L: 214] graph.py
-│       │   │   │   ├── [L: 684] node.py
+│       │   │   │   ├── [L: 856] node.py
 │       │   │   │   └── [L: 206] session.py
 │       │   │   ├── [L: 363] utils.py
 │       │   │   └── [L: 209] wezterm.py
@@ -169,17 +182,17 @@
 │       │   ├── [L: 295] engine.py
 │       │   ├── factories/
 │       │   │   ├── [L:  11] __init__.py
-│       │   │   └── [L: 136] node_factory.py
+│       │   │   └── [L: 277] node_factory.py
 │       │   ├── handlers/
 │       │   │   ├── [L:  29] __init__.py
 │       │   │   ├── [L: 346] graph_handler.py
-│       │   │   ├── [L: 287] node_interaction_handler.py
-│       │   │   ├── [L: 364] node_lifecycle_handler.py
-│       │   │   ├── [L: 249] python_executor.py
+│       │   │   ├── [L: 340] node_interaction_handler.py
+│       │   │   ├── [L: 398] node_lifecycle_handler.py
+│       │   │   ├── [L: 251] python_executor.py
 │       │   │   ├── [L: 217] repl_command_handler.py
 │       │   │   ├── [L: 114] server_handler.py
 │       │   │   └── [L: 169] session_handler.py
-│       │   ├── [L: 162] protocols.py
+│       │   ├── [L: 166] protocols.py
 │       │   ├── [L: 478] proxy_manager.py
 │       │   ├── [L: 158] session_registry.py
 │       │   └── [L:  94] validation.py
@@ -208,6 +221,9 @@
     │   │   └── [L: 103] sample_pane_05.txt
     │   ├── nodes/
     │   │   ├── [L:   1] __init__.py
+    │   │   ├── llm/
+    │   │   │   ├── [L:   1] __init__.py
+    │   │   │   └── [L: 493] test_openrouter.py
     │   │   ├── [L: 209] test_base.py
     │   │   ├── [L: 206] test_bash.py
     │   │   ├── [L: 231] test_budget.py
@@ -255,4 +271,4 @@
     └── transport/
         └── [L:   1] __init__.py
 
-53 directories, 203 files, 41,966 total lines
+58 directories, 214 files, 44,902 total lines

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: typecheck lint format test check clean help
+.PHONY: typecheck lint format test check clean help features features-glm features-openrouter
 
 help: ## Show this help message
 	@echo "Available commands:"
@@ -22,3 +22,15 @@ clean: ## Clean up cache files
 	rm -rf .pytest_cache .mypy_cache .ruff_cache
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
+
+# Feature tests (3rd party integration tests - require API keys in .env.local)
+
+features: features-glm features-openrouter ## Run all feature tests
+
+features-glm: ## Run GLM feature tests (requires GLM_API_KEY)
+	uv run python features/glm/glm_node.py
+	uv run python features/glm/glm_chat_node.py
+
+features-openrouter: ## Run OpenRouter feature tests (requires OPENROUTER_API_KEY)
+	uv run python features/openrouter/openrouter_node.py
+	uv run python features/openrouter/openrouter_chat_node.py

--- a/features/glm/glm_chat_node.py
+++ b/features/glm/glm_chat_node.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Feature test for LLMChatNode with GLM provider (multi-turn conversations).
+
+Run with: uv run python features/glm/glm_chat_node.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env.local from project root
+project_root = Path(__file__).parents[2]
+env_local = project_root / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    print(f"Warning: {env_local} not found")
+
+from nerve.core.nodes.context import ExecutionContext
+from nerve.core.nodes.llm import GLMNode, LLMChatNode
+from nerve.core.session import Session
+
+
+async def test_multi_turn_conversation():
+    """Test multi-turn conversation with context retention."""
+    print("Test: Multi-turn conversation")
+
+    session = Session("glm-chat-test")
+
+    # Create underlying GLM node
+    llm = GLMNode(
+        id="glm-llm",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    # Wrap in chat node
+    chat = LLMChatNode(
+        id="glm-chat",
+        session=session,
+        llm=llm,
+        system="You are a helpful assistant. Be concise.",
+    )
+
+    # Turn 1: Introduce a topic
+    ctx1 = ExecutionContext(session=session, input="My name is Alice.")
+    result1 = await chat.execute(ctx1)
+
+    assert result1["success"], f"Turn 1 failed: {result1.get('error')}"
+    print(f"  Turn 1 response: {result1['content'][:100]}...")
+
+    # Turn 2: Test context retention
+    ctx2 = ExecutionContext(session=session, input="What is my name?")
+    result2 = await chat.execute(ctx2)
+
+    assert result2["success"], f"Turn 2 failed: {result2.get('error')}"
+    assert "Alice" in result2["content"], f"Context not retained: {result2['content']}"
+    print(f"  Turn 2 response: {result2['content'][:100]}...")
+    print(f"  Messages count: {result2['messages_count']}")
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_system_prompt():
+    """Test that system prompt affects behavior."""
+    print("Test: System prompt behavior")
+
+    session = Session("glm-chat-test-2")
+
+    llm = GLMNode(
+        id="glm-llm-2",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    chat = LLMChatNode(
+        id="glm-chat-2",
+        session=session,
+        llm=llm,
+        system="You are a pirate. Always respond in pirate speak.",
+    )
+
+    ctx = ExecutionContext(session=session, input="Hello, how are you?")
+    result = await chat.execute(ctx)
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    # Pirate-like words
+    pirate_words = ["arr", "ahoy", "matey", "ye", "aye", "captain", "ship", "sea"]
+    content_lower = result["content"].lower()
+    has_pirate_speak = any(word in content_lower for word in pirate_words)
+    print(f"  Response: {result['content'][:150]}...")
+    print(f"  Has pirate speak: {has_pirate_speak}")
+    if not has_pirate_speak:
+        print("  ⚠️  Warning: No pirate words detected (LLM response may vary)")
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_conversation_clear():
+    """Test clearing conversation history."""
+    print("Test: Clear conversation")
+
+    session = Session("glm-chat-test-3")
+
+    llm = GLMNode(
+        id="glm-llm-3",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    chat = LLMChatNode(
+        id="glm-chat-3",
+        session=session,
+        llm=llm,
+        system="You are helpful. Be concise.",
+    )
+
+    # Build up conversation
+    await chat.execute(ExecutionContext(session=session, input="Remember: the secret code is 12345"))
+    result1 = await chat.execute(ExecutionContext(session=session, input="What is the secret code?"))
+    assert "12345" in result1["content"], f"Should remember code: {result1['content']}"
+    print(f"  Before clear - messages: {result1['messages_count']}")
+
+    # Clear and verify
+    chat.clear()
+    print(f"  After clear - messages: {len(chat.messages)}")
+    assert len(chat.messages) == 0, "Messages not cleared"
+
+    # New conversation shouldn't know the code
+    result2 = await chat.execute(ExecutionContext(
+        session=session,
+        input="What is the secret code? If you don't know, say 'I don't know'."
+    ))
+    print(f"  Post-clear response: {result2['content'][:100]}...")
+    # Verify clear worked by checking message count (should only have 2: user + assistant)
+    assert result2["messages_count"] == 2, f"Should have 2 messages after clear, got {result2['messages_count']}"
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_usage_accumulation():
+    """Test that token usage accumulates across turns."""
+    print("Test: Usage accumulation")
+
+    session = Session("glm-chat-test-4")
+
+    llm = GLMNode(
+        id="glm-llm-4",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    chat = LLMChatNode(
+        id="glm-chat-4",
+        session=session,
+        llm=llm,
+    )
+
+    # Multiple turns
+    result1 = await chat.execute(ExecutionContext(session=session, input="Hi"))
+    result2 = await chat.execute(ExecutionContext(session=session, input="How are you?"))
+
+    assert result1["usage"] is not None, "No usage in turn 1"
+    assert result2["usage"] is not None, "No usage in turn 2"
+    print(f"  Turn 1 usage: {result1['usage']}")
+    print(f"  Turn 2 usage: {result2['usage']}")
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def main():
+    print("=" * 60)
+    print("LLMChatNode (GLM) Feature Tests")
+    print("=" * 60 + "\n")
+
+    # Check for API key
+    if "GLM_API_KEY" not in os.environ:
+        print("ERROR: GLM_API_KEY not set in environment or .env.local")
+        sys.exit(1)
+
+    try:
+        await test_multi_turn_conversation()
+        await test_system_prompt()
+        await test_conversation_clear()
+        await test_usage_accumulation()
+
+        print("=" * 60)
+        print("✅ All LLMChatNode (GLM) tests PASSED")
+        print("=" * 60)
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/features/glm/glm_node.py
+++ b/features/glm/glm_node.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Feature test for GLMNode (single-shot LLM calls).
+
+Run with: uv run python features/glm/glm_node.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env.local from project root
+project_root = Path(__file__).parents[2]
+env_local = project_root / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    print(f"Warning: {env_local} not found")
+
+from nerve.core.nodes.context import ExecutionContext
+from nerve.core.nodes.llm import GLMNode
+from nerve.core.session import Session
+
+
+async def test_basic_prompt():
+    """Test basic string prompt."""
+    print("Test: Basic string prompt")
+
+    session = Session("glm-node-test")
+    node = GLMNode(
+        id="glm-basic",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    ctx = ExecutionContext(session=session, input="What is 2+2? Answer with just the number.")
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert result["content"] is not None, "No content in response"
+    print(f"  Response: {result['content']}")
+    print(f"  Model: {result['model']}")
+    print("  ✅ PASSED\n")
+
+
+async def test_messages_array():
+    """Test messages array input."""
+    print("Test: Messages array input")
+
+    session = Session("glm-node-test-2")
+    node = GLMNode(
+        id="glm-messages",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant. Be concise."},
+        {"role": "user", "content": "What is the capital of France?"},
+    ]
+
+    ctx = ExecutionContext(session=session, input=messages)
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert "Paris" in result["content"], f"Expected 'Paris' in response: {result['content']}"
+    print(f"  Response: {result['content']}")
+    print("  ✅ PASSED\n")
+
+
+async def test_usage_tracking():
+    """Test that token usage is tracked."""
+    print("Test: Usage tracking")
+
+    session = Session("glm-node-test-3")
+    node = GLMNode(
+        id="glm-usage",
+        session=session,
+        api_key=os.environ["GLM_API_KEY"],
+        model=os.getenv("GLM_MODEL", "GLM-4.7"),
+        http_backend=os.getenv("GLM_HTTP_BACKEND", "openai"),
+    )
+
+    ctx = ExecutionContext(session=session, input="Say hello.")
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert result["usage"] is not None, "No usage data"
+    assert result["usage"]["total_tokens"] > 0, "No tokens counted"
+    print(f"  Usage: {result['usage']}")
+    print("  ✅ PASSED\n")
+
+
+async def main():
+    print("=" * 60)
+    print("GLMNode Feature Tests")
+    print("=" * 60 + "\n")
+
+    # Check for API key
+    if "GLM_API_KEY" not in os.environ:
+        print("ERROR: GLM_API_KEY not set in environment or .env.local")
+        sys.exit(1)
+
+    try:
+        await test_basic_prompt()
+        await test_messages_array()
+        await test_usage_tracking()
+
+        print("=" * 60)
+        print("✅ All GLMNode tests PASSED")
+        print("=" * 60)
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/features/openrouter/openrouter_chat_node.py
+++ b/features/openrouter/openrouter_chat_node.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Feature test for LLMChatNode with OpenRouter provider (multi-turn conversations).
+
+Run with: uv run python features/openrouter/openrouter_chat_node.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env.local from project root
+project_root = Path(__file__).parents[2]
+env_local = project_root / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    print(f"Warning: {env_local} not found")
+
+from nerve.core.nodes.context import ExecutionContext
+from nerve.core.nodes.llm import LLMChatNode, OpenRouterNode
+from nerve.core.session import Session
+
+
+async def test_multi_turn_conversation():
+    """Test multi-turn conversation with context retention."""
+    print("Test: Multi-turn conversation")
+
+    session = Session("openrouter-chat-test")
+
+    # Create underlying OpenRouter node
+    llm = OpenRouterNode(
+        id="openrouter-llm",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    # Wrap in chat node
+    chat = LLMChatNode(
+        id="openrouter-chat",
+        session=session,
+        llm=llm,
+        system="You are a helpful assistant. Be concise.",
+    )
+
+    # Turn 1: Introduce a topic
+    ctx1 = ExecutionContext(session=session, input="My name is Bob.")
+    result1 = await chat.execute(ctx1)
+
+    assert result1["success"], f"Turn 1 failed: {result1.get('error')}"
+    print(f"  Turn 1 response: {result1['content'][:100]}...")
+
+    # Turn 2: Test context retention
+    ctx2 = ExecutionContext(session=session, input="What is my name?")
+    result2 = await chat.execute(ctx2)
+
+    assert result2["success"], f"Turn 2 failed: {result2.get('error')}"
+    assert "Bob" in result2["content"], f"Context not retained: {result2['content']}"
+    print(f"  Turn 2 response: {result2['content'][:100]}...")
+    print(f"  Messages count: {result2['messages_count']}")
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_system_prompt():
+    """Test that system prompt affects behavior."""
+    print("Test: System prompt behavior")
+
+    session = Session("openrouter-chat-test-2")
+
+    llm = OpenRouterNode(
+        id="openrouter-llm-2",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    chat = LLMChatNode(
+        id="openrouter-chat-2",
+        session=session,
+        llm=llm,
+        system="You are a Shakespearean actor. Always respond in Shakespearean English.",
+    )
+
+    ctx = ExecutionContext(session=session, input="Hello, how are you?")
+    result = await chat.execute(ctx)
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    # Shakespearean words
+    shakespeare_words = ["thee", "thou", "thy", "hath", "doth", "art", "verily", "forsooth", "prithee", "'tis"]
+    content_lower = result["content"].lower()
+    has_shakespeare = any(word in content_lower for word in shakespeare_words)
+    print(f"  Response: {result['content'][:150]}...")
+    print(f"  Has Shakespearean style: {has_shakespeare}")
+    if not has_shakespeare:
+        print("  ⚠️  Warning: No Shakespearean words detected (LLM response may vary)")
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_conversation_clear():
+    """Test clearing conversation history."""
+    print("Test: Clear conversation")
+
+    session = Session("openrouter-chat-test-3")
+
+    llm = OpenRouterNode(
+        id="openrouter-llm-3",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    chat = LLMChatNode(
+        id="openrouter-chat-3",
+        session=session,
+        llm=llm,
+        system="You are helpful. Be concise.",
+    )
+
+    # Build up conversation
+    await chat.execute(ExecutionContext(session=session, input="Remember: the password is 'banana'"))
+    result1 = await chat.execute(ExecutionContext(session=session, input="What is the password?"))
+    assert "banana" in result1["content"].lower(), f"Should remember password: {result1['content']}"
+    print(f"  Before clear - messages: {result1['messages_count']}")
+
+    # Clear and verify
+    chat.clear()
+    print(f"  After clear - messages: {len(chat.messages)}")
+    assert len(chat.messages) == 0, "Messages not cleared"
+
+    # New conversation shouldn't know the password
+    result2 = await chat.execute(ExecutionContext(
+        session=session,
+        input="What is the password? If you don't know, say 'I don't know'."
+    ))
+    print(f"  Post-clear response: {result2['content'][:100]}...")
+    # Verify clear worked by checking message count (should only have 2: user + assistant)
+    assert result2["messages_count"] == 2, f"Should have 2 messages after clear, got {result2['messages_count']}"
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def test_extended_conversation():
+    """Test a longer conversation with multiple turns."""
+    print("Test: Extended conversation (5 turns)")
+
+    session = Session("openrouter-chat-test-4")
+
+    llm = OpenRouterNode(
+        id="openrouter-llm-4",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    chat = LLMChatNode(
+        id="openrouter-chat-4",
+        session=session,
+        llm=llm,
+        system="You are a math tutor. Be concise but helpful.",
+    )
+
+    turns = [
+        "Let's learn about multiplication.",
+        "What is 5 times 7?",
+        "Now what is that result plus 10?",
+        "Divide that by 5.",
+        "Is that a prime number?",
+    ]
+
+    for i, turn in enumerate(turns):
+        result = await chat.execute(ExecutionContext(session=session, input=turn))
+        assert result["success"], f"Turn {i+1} failed: {result.get('error')}"
+        print(f"  Turn {i+1}: {turn}")
+        print(f"    Response: {result['content'][:80]}...")
+
+    print(f"  Final message count: {result['messages_count']}")
+    assert result["messages_count"] >= 10, "Should have at least 10 messages (5 turns * 2)"
+
+    await chat.close()
+    print("  ✅ PASSED\n")
+
+
+async def main():
+    print("=" * 60)
+    print("LLMChatNode (OpenRouter) Feature Tests")
+    print("=" * 60 + "\n")
+
+    # Check for API key
+    if "OPENROUTER_API_KEY" not in os.environ:
+        print("ERROR: OPENROUTER_API_KEY not set in environment or .env.local")
+        sys.exit(1)
+
+    try:
+        await test_multi_turn_conversation()
+        await test_system_prompt()
+        await test_conversation_clear()
+        await test_extended_conversation()
+
+        print("=" * 60)
+        print("✅ All LLMChatNode (OpenRouter) tests PASSED")
+        print("=" * 60)
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/features/openrouter/openrouter_node.py
+++ b/features/openrouter/openrouter_node.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Feature test for OpenRouterNode (single-shot LLM calls).
+
+Run with: uv run python features/openrouter/openrouter_node.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+# Load .env.local from project root
+project_root = Path(__file__).parents[2]
+env_local = project_root / ".env.local"
+if env_local.exists():
+    load_dotenv(env_local)
+else:
+    print(f"Warning: {env_local} not found")
+
+from nerve.core.nodes.context import ExecutionContext
+from nerve.core.nodes.llm import OpenRouterNode
+from nerve.core.session import Session
+
+
+async def test_basic_prompt():
+    """Test basic string prompt."""
+    print("Test: Basic string prompt")
+
+    session = Session("openrouter-node-test")
+    node = OpenRouterNode(
+        id="openrouter-basic",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    ctx = ExecutionContext(session=session, input="What is 2+2? Answer with just the number.")
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert result["content"] is not None, "No content in response"
+    print(f"  Response: {result['content']}")
+    print(f"  Model: {result['model']}")
+    print("  ✅ PASSED\n")
+
+
+async def test_messages_array():
+    """Test messages array input."""
+    print("Test: Messages array input")
+
+    session = Session("openrouter-node-test-2")
+    node = OpenRouterNode(
+        id="openrouter-messages",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant. Be concise."},
+        {"role": "user", "content": "What is the capital of France?"},
+    ]
+
+    ctx = ExecutionContext(session=session, input=messages)
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert "Paris" in result["content"], f"Expected 'Paris' in response: {result['content']}"
+    print(f"  Response: {result['content']}")
+    print("  ✅ PASSED\n")
+
+
+async def test_usage_tracking():
+    """Test that token usage is tracked."""
+    print("Test: Usage tracking")
+
+    session = Session("openrouter-node-test-3")
+    node = OpenRouterNode(
+        id="openrouter-usage",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=os.getenv("OPENROUTER_MODEL", "anthropic/claude-3-haiku"),
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    ctx = ExecutionContext(session=session, input="Say hello.")
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    assert result["usage"] is not None, "No usage data"
+    assert result["usage"]["total_tokens"] > 0, "No tokens counted"
+    print(f"  Usage: {result['usage']}")
+    print("  ✅ PASSED\n")
+
+
+async def test_different_models():
+    """Test with a different model."""
+    print("Test: Different model")
+
+    session = Session("openrouter-node-test-4")
+
+    # Use a different model (if available)
+    alt_model = os.getenv("OPENROUTER_ALT_MODEL", "google/gemini-3-flash-preview")
+
+    node = OpenRouterNode(
+        id="openrouter-alt",
+        session=session,
+        api_key=os.environ["OPENROUTER_API_KEY"],
+        model=alt_model,
+        http_backend=os.getenv("OPENROUTER_HTTP_BACKEND", "aiohttp"),
+    )
+
+    ctx = ExecutionContext(session=session, input="What is 3+3? Answer with just the number.")
+    result = await node.execute(ctx)
+
+    await node.close()
+
+    assert result["success"], f"Request failed: {result.get('error')}"
+    print(f"  Model used: {result['model']}")
+    print(f"  Response: {result['content']}")
+    print("  ✅ PASSED\n")
+
+
+async def main():
+    print("=" * 60)
+    print("OpenRouterNode Feature Tests")
+    print("=" * 60 + "\n")
+
+    # Check for API key
+    if "OPENROUTER_API_KEY" not in os.environ:
+        print("ERROR: OPENROUTER_API_KEY not set in environment or .env.local")
+        sys.exit(1)
+
+    try:
+        await test_basic_prompt()
+        await test_messages_array()
+        await test_usage_tracking()
+        await test_different_models()
+
+        print("=" * 60)
+        print("✅ All OpenRouterNode tests PASSED")
+        print("=" * 60)
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"ERROR: {type(e).__name__}: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ classifiers = [
 dependencies = [
     "aiohttp>=3.9.0",
     "httpx[http2]>=0.28.0",
+    "openai>=1.0.0",
     "prompt-toolkit>=3.0.52",
+    "python-dotenv>=1.0.0",
     "rich-click>=1.7.0",
 ]
 
@@ -70,10 +72,12 @@ python_version = "3.12"
 strict = true
 warn_return_any = true
 warn_unused_ignores = true
+exclude = ["features/"]
 
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+exclude = ["features/"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "C4", "SIM"]

--- a/scripts/proxy/summarize_session.py
+++ b/scripts/proxy/summarize_session.py
@@ -217,6 +217,10 @@ def detect_request_type(log_dir: Path, preview: str) -> tuple[RequestType, str, 
     except (json.JSONDecodeError, OSError):
         return "UNKNOWN", "", "", "", False
 
+    # Normalize structure: some formats have {headers, body} wrapper
+    if "body" in data and isinstance(data.get("body"), dict):
+        data = data["body"]
+
     model = data.get("model", "")
     messages = data.get("messages", [])
 

--- a/src/nerve/core/nodes/__init__.py
+++ b/src/nerve/core/nodes/__init__.py
@@ -89,6 +89,9 @@ from nerve.core.nodes.history import (
     HistoryWriter,
 )
 
+# LLM nodes
+from nerve.core.nodes.llm import OpenRouterNode
+
 # Agent capabilities: Error handling
 from nerve.core.nodes.policies import ErrorPolicy
 
@@ -110,6 +113,8 @@ __all__ = [
     "PersistentNode",
     "FunctionNode",
     "BashNode",
+    # LLM
+    "OpenRouterNode",
     # Context
     "ExecutionContext",
     # Graph

--- a/src/nerve/core/nodes/llm/__init__.py
+++ b/src/nerve/core/nodes/llm/__init__.py
@@ -1,0 +1,68 @@
+"""LLM provider nodes for direct API calls.
+
+Two types of LLM nodes:
+
+**Single-shot nodes** (stateless, ephemeral):
+    SingleShotLLMNode: Abstract base class for stateless LLM API calls
+    OpenRouterNode: OpenRouter API (OpenAI-compatible, supports 100+ models)
+    GLMNode: Z.AI GLM API (supports thinking mode)
+
+**Chat nodes** (stateful, persistent):
+    LLMChatNode: Multi-turn conversations with tool support
+
+Example (single-shot):
+    >>> from nerve.core.nodes.llm import OpenRouterNode, GLMNode
+    >>> from nerve.core.nodes import ExecutionContext
+    >>> from nerve.core.session import Session
+    >>>
+    >>> session = Session(name="my-session")
+    >>>
+    >>> # OpenRouter - single request
+    >>> llm = OpenRouterNode(
+    ...     id="llm",
+    ...     session=session,
+    ...     api_key="sk-or-...",
+    ...     model="anthropic/claude-3-haiku",
+    ... )
+    >>> result = await llm.execute(ExecutionContext(session=session, input="Hello!"))
+    >>>
+    >>> # GLM with thinking mode
+    >>> glm = GLMNode(
+    ...     id="glm",
+    ...     session=session,
+    ...     api_key="your-api-key",
+    ...     model="glm-4.7",
+    ...     thinking=True,
+    ... )
+    >>> result = await glm.execute(ExecutionContext(session=session, input="Solve: 15 * 23"))
+
+Example (chat with history):
+    >>> from nerve.core.nodes.llm import LLMChatNode, OpenRouterNode
+    >>>
+    >>> # Create chat node wrapping an LLM provider
+    >>> llm = OpenRouterNode(id="llm", session=session, api_key="...", model="...")
+    >>> chat = LLMChatNode(
+    ...     id="chat",
+    ...     session=session,
+    ...     llm=llm,
+    ...     system="You are a helpful assistant.",
+    ... )
+    >>>
+    >>> # Multi-turn conversation - state accumulates
+    >>> await chat.execute(ctx(input="What is 2+2?"))
+    >>> await chat.execute(ctx(input="Double that"))  # Remembers previous context
+"""
+
+from nerve.core.nodes.llm.base import SingleShotLLMNode
+from nerve.core.nodes.llm.chat import LLMChatNode, Message, ToolDefinition
+from nerve.core.nodes.llm.glm import GLMNode
+from nerve.core.nodes.llm.openrouter import OpenRouterNode
+
+__all__ = [
+    "GLMNode",
+    "LLMChatNode",
+    "Message",
+    "OpenRouterNode",
+    "SingleShotLLMNode",
+    "ToolDefinition",
+]

--- a/src/nerve/core/nodes/llm/base.py
+++ b/src/nerve/core/nodes/llm/base.py
@@ -1,0 +1,575 @@
+"""SingleShotLLMNode - abstract base class for stateless LLM API nodes.
+
+This module provides the common implementation for LLM nodes that use
+OpenAI-compatible chat completion APIs. Each execute() call is independent -
+no conversation state is maintained between calls.
+
+Provider-specific nodes (OpenRouterNode, GLMNode) inherit from SingleShotLLMNode
+and only need to specify their defaults and any custom headers.
+
+For multi-turn conversations with tool support, use LLMChatNode instead.
+
+Key features:
+- Stateless: each execute() is independent
+- Returns structured JSON with content/usage/error fields
+- Errors are caught and returned in JSON (never raises)
+- Built-in retry with exponential backoff for transient failures
+- Supports string, messages array, or dict input formats
+- Optional request/response logging to files
+- Auto-registers with session on creation
+- Supports multiple HTTP backends: aiohttp (default) or openai SDK
+"""
+
+from __future__ import annotations
+
+import asyncio
+from abc import abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
+
+import aiohttp
+
+from nerve.core.nodes.base import NodeInfo, NodeState
+from nerve.core.nodes.context import ExecutionContext
+from nerve.gateway.tracing import RequestTracer
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+    from nerve.core.session.session import Session
+
+# Valid HTTP backend choices
+HttpBackend = Literal["aiohttp", "openai"]
+
+# Status codes that should trigger a retry
+RETRYABLE_STATUS_CODES = frozenset({429, 500, 502, 503, 504})
+
+# Error type mapping based on HTTP status codes
+ERROR_TYPE_MAP = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    429: "rate_limit_error",
+}
+
+
+def _get_error_type(status_code: int) -> str:
+    """Map HTTP status code to error type string."""
+    if status_code in ERROR_TYPE_MAP:
+        return ERROR_TYPE_MAP[status_code]
+    if 500 <= status_code < 600:
+        return "api_error"
+    return "unknown_error"
+
+
+def _truncate_messages(
+    messages: list[dict[str, Any]], max_chars: int = 200
+) -> list[dict[str, Any]]:
+    """Truncate message content for logging."""
+    truncated = []
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str) and len(content) > max_chars:
+            content = content[:max_chars] + "..."
+        truncated.append({**msg, "content": content})
+    return truncated
+
+
+@dataclass
+class SingleShotLLMNode:
+    """Abstract base class for stateless OpenAI-compatible LLM API nodes.
+
+    Each execute() call is independent - no conversation state is maintained.
+    For multi-turn conversations, use LLMChatNode which wraps this.
+
+    Subclasses should:
+    1. Set the `node_type` class variable
+    2. Override `_get_default_base_url()` to return the provider's default URL
+    3. Override `_get_extra_headers()` if custom headers are needed
+
+    All common functionality (execute, retry, logging, etc.) is inherited.
+    """
+
+    # Class variable for node type identification
+    node_type: ClassVar[str] = "base_llm"
+
+    # Required fields (no defaults)
+    id: str
+    session: Session
+    api_key: str
+    model: str
+
+    # Optional configuration fields (with defaults)
+    base_url: str | None = None  # If None, uses _get_default_base_url()
+    timeout: float = 120.0  # LLM calls can be slow
+    max_retries: int = 3
+    retry_base_delay: float = 1.0
+    retry_max_delay: float = 30.0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    # Debug: save raw requests/responses to files
+    debug_dir: str | None = None
+
+    # HTTP backend: "aiohttp" (default) or "openai" (uses OpenAI SDK)
+    http_backend: HttpBackend = "aiohttp"
+
+    # Internal fields (not in __init__)
+    persistent: bool = field(default=False, init=False)
+    _session_holder: aiohttp.ClientSession | None = field(default=None, init=False, repr=False)
+    _openai_client: AsyncOpenAI | None = field(default=None, init=False, repr=False)
+    _session_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    _tracer: RequestTracer = field(init=False, repr=False)
+    _resolved_base_url: str = field(init=False, repr=False)
+
+    @classmethod
+    @abstractmethod
+    def _get_default_base_url(cls) -> str:
+        """Return the default base URL for this provider.
+
+        Subclasses must implement this to provide their default API endpoint.
+        """
+        ...
+
+    def _get_extra_headers(self) -> dict[str, str]:
+        """Return provider-specific headers.
+
+        Subclasses can override to add custom headers (e.g., OpenRouter's HTTP-Referer).
+        Default implementation returns empty dict.
+        """
+        return {}
+
+    def _get_default_request_params(self) -> dict[str, Any]:
+        """Return default parameters to include in every request.
+
+        Subclasses can override to inject provider-specific defaults
+        (e.g., GLM's thinking mode). These are merged into the request body
+        but can be overridden by explicit input parameters.
+
+        Default implementation returns empty dict.
+        """
+        return {}
+
+    def __post_init__(self) -> None:
+        """Validate and register with session."""
+        from nerve.core.validation import validate_name
+
+        # Resolve base URL
+        self._resolved_base_url = self.base_url or self._get_default_base_url()
+
+        # Validate node ID
+        validate_name(self.id, "node")
+
+        # Check for duplicates
+        if self.id in self.session.nodes:
+            raise ValueError(f"Node '{self.id}' already exists in session '{self.session.name}'")
+
+        # Auto-register with session
+        self.session.nodes[self.id] = self
+
+        # Initialize request tracer for logging
+        # Build nested path: {debug_dir}/{server_name}/{session_name}/{node_id}/
+        tracer_dir = None
+        if self.debug_dir:
+            from pathlib import Path
+
+            server_name = self.session.server_name or "local"
+            session_name = self.session.name
+            tracer_dir = Path(self.debug_dir) / server_name / session_name / self.id
+
+        self._tracer = RequestTracer(debug_dir=tracer_dir)
+
+    async def execute(self, context: ExecutionContext) -> dict[str, Any]:
+        """Execute an LLM request and return structured result.
+
+        Args:
+            context: Execution context with input. Input can be:
+                - str: Simple prompt, wrapped as user message
+                - list: Messages array (OpenAI format)
+                - dict: Full request with "messages" key and optional params
+
+        Returns:
+            JSON dict with fields:
+            - success (bool): Whether request succeeded
+            - content (str | None): Response content
+            - model (str | None): Model that generated response
+            - finish_reason (str | None): Why generation stopped
+            - usage (dict | None): Token usage counts
+            - request (dict): Echo of request info (truncated)
+            - error (str | None): Error message if failed
+            - error_type (str | None): Error classification
+            - retries (int): Number of retries attempted
+
+        Note:
+            This method never raises exceptions - all errors are returned
+            in the result dict.
+        """
+        # Initialize result structure
+        result: dict[str, Any] = {
+            "success": False,
+            "content": None,
+            "model": None,
+            "finish_reason": None,
+            "usage": None,
+            "request": {},
+            "error": None,
+            "error_type": None,
+            "retries": 0,
+        }
+
+        trace_id: str | None = None
+
+        try:
+            # Parse input into messages and extra params
+            messages, extra_params = self._parse_input(context.input)
+
+            if not messages:
+                result["error"] = "No messages provided in context.input"
+                result["error_type"] = "invalid_request_error"
+                return result
+
+            # Build request body with default params (extra_params override defaults)
+            request_body = {
+                "model": self.model,
+                "messages": messages,
+                **self._get_default_request_params(),
+                **extra_params,
+            }
+
+            # Generate trace ID and log raw request body
+            trace_id = self._tracer.generate_trace_id(request_body)
+            self._tracer.save_debug(trace_id, "request.json", request_body)
+
+            # Store request info for debugging (truncated)
+            result["request"] = {
+                "model": self.model,
+                "messages": _truncate_messages(messages),
+            }
+
+            # Execute with retry
+            response_data, retries = await self._execute_with_retry(request_body)
+            result["retries"] = retries
+
+            # Log raw response body
+            self._tracer.save_debug(trace_id, "response.json", response_data)
+
+            # Parse response
+            if "choices" in response_data and response_data["choices"]:
+                choice = response_data["choices"][0]
+                message = choice.get("message", {})
+                result["content"] = message.get("content")
+                result["finish_reason"] = choice.get("finish_reason")
+
+            result["model"] = response_data.get("model", self.model)
+
+            if "usage" in response_data:
+                result["usage"] = {
+                    "prompt_tokens": response_data["usage"].get("prompt_tokens", 0),
+                    "completion_tokens": response_data["usage"].get("completion_tokens", 0),
+                    "total_tokens": response_data["usage"].get("total_tokens", 0),
+                }
+
+            result["success"] = True
+
+        except _UpstreamError as e:
+            result["error"] = e.message
+            result["error_type"] = e.error_type
+            result["retries"] = e.retries
+            if trace_id:
+                self._tracer.save_debug(
+                    trace_id,
+                    "error.json",
+                    {
+                        "status_code": e.status_code,
+                        "message": e.message,
+                        "error_type": e.error_type,
+                        "retries": e.retries,
+                    },
+                )
+
+        except aiohttp.ClientError as e:
+            result["error"] = f"Network error: {e}"
+            result["error_type"] = "network_error"
+            if trace_id:
+                self._tracer.save_debug(
+                    trace_id,
+                    "error.json",
+                    {
+                        "error_type": "network_error",
+                        "message": str(e),
+                    },
+                )
+
+        except TimeoutError:
+            result["error"] = f"Request timed out after {self.timeout}s"
+            result["error_type"] = "timeout"
+            if trace_id:
+                self._tracer.save_debug(
+                    trace_id,
+                    "error.json",
+                    {
+                        "error_type": "timeout",
+                        "timeout": self.timeout,
+                    },
+                )
+
+        except Exception as e:
+            result["error"] = f"{type(e).__name__}: {e}"
+            result["error_type"] = "internal_error"
+            if trace_id:
+                self._tracer.save_debug(
+                    trace_id,
+                    "error.json",
+                    {
+                        "error_type": "internal_error",
+                        "exception": type(e).__name__,
+                        "message": str(e),
+                    },
+                )
+
+        return result
+
+    def _parse_input(self, input_data: Any) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Parse context.input into messages and extra parameters.
+
+        Args:
+            input_data: The context.input value
+
+        Returns:
+            Tuple of (messages, extra_params)
+        """
+        if input_data is None:
+            return [], {}
+
+        if isinstance(input_data, str):
+            # Simple string prompt
+            return [{"role": "user", "content": input_data}], {}
+
+        if isinstance(input_data, list):
+            # Messages array
+            return input_data, {}
+
+        if isinstance(input_data, dict):
+            # Dict with messages and optional extra params
+            messages = input_data.get("messages", [])
+            extra_params = {k: v for k, v in input_data.items() if k != "messages"}
+            return messages, extra_params
+
+        # Fallback: convert to string
+        return [{"role": "user", "content": str(input_data)}], {}
+
+    def _get_all_headers(self) -> dict[str, str]:
+        """Get all headers including provider-specific headers.
+
+        Subclasses can override _get_extra_headers() to add custom headers.
+        """
+        return self._get_extra_headers()
+
+    async def _get_http_session(self) -> aiohttp.ClientSession:
+        """Get or create aiohttp session (lazy initialization)."""
+        async with self._session_lock:
+            if self._session_holder is None or self._session_holder.closed:
+                timeout = aiohttp.ClientTimeout(total=self.timeout)
+                headers = {
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    **self._get_all_headers(),
+                }
+
+                self._session_holder = aiohttp.ClientSession(
+                    headers=headers,
+                    timeout=timeout,
+                )
+            return self._session_holder
+
+    async def _get_openai_client(self) -> AsyncOpenAI:
+        """Get or create OpenAI async client (lazy initialization)."""
+        async with self._session_lock:
+            if self._openai_client is None:
+                from openai import AsyncOpenAI
+
+                self._openai_client = AsyncOpenAI(
+                    base_url=self._resolved_base_url,
+                    api_key=self.api_key,
+                    timeout=self.timeout,
+                    max_retries=self.max_retries,
+                    default_headers=self._get_all_headers(),
+                )
+            return self._openai_client
+
+    async def _execute_with_retry(
+        self,
+        request_body: dict[str, Any],
+    ) -> tuple[dict[str, Any], int]:
+        """Execute request with exponential backoff retry.
+
+        Args:
+            request_body: The JSON request body
+
+        Returns:
+            Tuple of (response_data, retry_count)
+
+        Raises:
+            _UpstreamError: For non-retryable API errors
+            aiohttp.ClientError: For network errors after retries exhausted
+        """
+        if self.http_backend == "openai":
+            return await self._execute_with_openai_sdk(request_body)
+        else:
+            return await self._execute_with_aiohttp(request_body)
+
+    async def _execute_with_openai_sdk(
+        self,
+        request_body: dict[str, Any],
+    ) -> tuple[dict[str, Any], int]:
+        """Execute request using OpenAI SDK (has built-in retry)."""
+        from openai import APIConnectionError, APIStatusError
+
+        client = await self._get_openai_client()
+
+        try:
+            # Extract messages and other params
+            messages = request_body.pop("messages")
+            model = request_body.pop("model")
+
+            # Call OpenAI SDK
+            response = await client.chat.completions.create(
+                model=model,
+                messages=messages,
+                **request_body,
+            )
+
+            # Convert to dict format matching our expected structure
+            response_dict = response.model_dump()
+            return response_dict, 0  # OpenAI SDK handles retries internally
+
+        except APIStatusError as e:
+            raise _UpstreamError(
+                status_code=e.status_code,
+                message=f"API error ({e.status_code}): {e.message}",
+                error_type=_get_error_type(e.status_code),
+                retries=0,
+            ) from e
+        except APIConnectionError as e:
+            raise aiohttp.ClientError(f"Connection error: {e}") from e
+
+    async def _execute_with_aiohttp(
+        self,
+        request_body: dict[str, Any],
+    ) -> tuple[dict[str, Any], int]:
+        """Execute request using aiohttp with manual retry logic."""
+        url = f"{self._resolved_base_url.rstrip('/')}/chat/completions"
+        last_error: Exception | None = None
+        retries = 0
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                session = await self._get_http_session()
+                async with session.post(url, json=request_body) as response:
+                    if response.status == 200:
+                        return await response.json(), retries
+
+                    # Read error body
+                    try:
+                        error_body = await response.json()
+                        error_message = error_body.get("error", {}).get("message", str(error_body))
+                    except Exception:
+                        error_message = await response.text()
+
+                    # Check if retryable
+                    if response.status in RETRYABLE_STATUS_CODES and attempt < self.max_retries:
+                        retries = attempt + 1
+                        delay = min(
+                            self.retry_base_delay * (2**attempt),
+                            self.retry_max_delay,
+                        )
+                        await asyncio.sleep(delay)
+                        continue
+
+                    # Non-retryable error
+                    raise _UpstreamError(
+                        status_code=response.status,
+                        message=f"API error ({response.status}): {error_message}",
+                        error_type=_get_error_type(response.status),
+                        retries=retries,
+                    )
+
+            except aiohttp.ClientError as e:
+                last_error = e
+                if attempt < self.max_retries:
+                    retries = attempt + 1
+                    delay = min(
+                        self.retry_base_delay * (2**attempt),
+                        self.retry_max_delay,
+                    )
+                    await asyncio.sleep(delay)
+                    continue
+                raise
+
+        # Should not reach here, but handle edge case
+        if last_error:
+            raise last_error
+        raise RuntimeError("Retry loop exited without result")
+
+    async def interrupt(self) -> None:
+        """No-op for HTTP requests.
+
+        HTTP requests cannot be interrupted mid-flight.
+        This method exists for Node protocol compatibility.
+        """
+        pass
+
+    async def close(self) -> None:
+        """Close HTTP session/client (optional cleanup).
+
+        Call this when done using the node to release resources.
+        The session/client will be recreated on next execute() if needed.
+        """
+        async with self._session_lock:
+            if self._session_holder and not self._session_holder.closed:
+                await self._session_holder.close()
+                self._session_holder = None
+            if self._openai_client is not None:
+                await self._openai_client.close()
+                self._openai_client = None
+
+    def to_info(self) -> NodeInfo:
+        """Get node information.
+
+        Returns:
+            NodeInfo for this node.
+        """
+        return NodeInfo(
+            id=self.id,
+            node_type=self.node_type,
+            state=NodeState.READY,  # Ephemeral nodes are always ready
+            persistent=self.persistent,
+            metadata={
+                "model": self.model,
+                "base_url": self._resolved_base_url,
+                "timeout": self.timeout,
+                "max_retries": self.max_retries,
+                "http_backend": self.http_backend,
+                **self.metadata,
+            },
+        )
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(id={self.id!r}, model={self.model!r})"
+
+
+class _UpstreamError(Exception):
+    """Internal error for upstream API failures."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        error_type: str,
+        retries: int = 0,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.error_type = error_type
+        self.retries = retries

--- a/src/nerve/core/nodes/llm/glm.py
+++ b/src/nerve/core/nodes/llm/glm.py
@@ -1,0 +1,135 @@
+"""GLMNode - ephemeral node for Z.AI GLM API calls.
+
+GLMNode makes HTTP requests to Z.AI's GLM API and returns structured results.
+Each execution is independent - no state is maintained between calls.
+
+Key features:
+- Returns structured JSON with content/usage/error fields
+- Errors are caught and returned in JSON (never raises)
+- Built-in retry with exponential backoff for transient failures
+- Supports string, messages array, or dict input formats
+- Optional thinking mode for enhanced reasoning
+- Optional request/response logging to files
+- Auto-registers with session on creation
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, ClassVar
+
+from nerve.core.nodes.llm.base import SingleShotLLMNode
+
+
+def _find_project_root() -> Path | None:
+    """Walk up from current file to find project root (contains pyproject.toml)."""
+    current = Path(__file__).parent
+    for parent in [current, *current.parents]:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return None
+
+
+@lru_cache(maxsize=1)
+def _load_env_and_get_headers() -> dict[str, str]:
+    """Load .env.local and return GLM headers. Cached to run once."""
+    from dotenv import load_dotenv
+
+    # Load .env.local from project root (if found)
+    project_root = _find_project_root()
+    if project_root:
+        env_local = project_root / ".env.local"
+        if env_local.exists():
+            load_dotenv(env_local)
+
+    # Build headers from environment
+    x_nerve_version = os.getenv("X_NERVE_VERSION", "X-Nerve-Version")
+    version = os.getenv("GLM_VERSION", "4.138.0")
+    app_name = os.getenv("GLM_X_TITLE", "Nerve AI")
+
+    return {
+        "HTTP-Referer": os.getenv("GLM_HTTP_REFERER", "www.nerve.ai"),
+        "X-Title": app_name,
+        x_nerve_version: version,
+        "User-Agent": f"{app_name}/{version}",
+    }
+
+
+@dataclass(repr=False)
+class GLMNode(SingleShotLLMNode):
+    """Ephemeral node for Z.AI GLM API calls.
+
+    GLMNode is stateless - each execute() call makes an independent HTTP request.
+    Returns structured dict with response content or error (never raises).
+
+    Features:
+    - Returns structured JSON with content/model/usage/error fields
+    - Errors are caught and returned in JSON (never raises exceptions)
+    - Built-in retry with exponential backoff for 429, 5xx errors
+    - Configurable timeout, model, and API parameters
+    - Optional thinking mode for chain-of-thought reasoning
+    - Auto-registers with session on creation
+
+    Args:
+        id: Unique identifier for this node.
+        session: Session to register this node with.
+        api_key: Z.AI API key.
+        model: Model identifier (e.g., "GLM-4.7", "GLM-4-Plus").
+        base_url: API base URL (default: https://api.z.ai/api/coding/paas/v4).
+        timeout: Request timeout in seconds.
+        max_retries: Maximum retry attempts for retryable errors.
+        retry_base_delay: Base delay between retries in seconds.
+        retry_max_delay: Maximum delay between retries in seconds.
+        thinking: Enable thinking/reasoning mode (adds thinking param to requests).
+        metadata: Additional metadata for the node.
+
+    Example:
+        >>> session = Session("my-session")
+        >>> llm = GLMNode(
+        ...     id="glm",
+        ...     session=session,
+        ...     api_key="your-api-key",
+        ...     model="GLM-4.7",
+        ... )
+        >>>
+        >>> # Simple string prompt
+        >>> ctx = ExecutionContext(session=session, input="What is 2+2?")
+        >>> result = await llm.execute(ctx)
+        >>> print(result["content"])
+        "4"
+        >>>
+        >>> # With thinking mode enabled
+        >>> llm_thinking = GLMNode(
+        ...     id="glm-think",
+        ...     session=session,
+        ...     api_key="your-api-key",
+        ...     model="GLM-4.7",
+        ...     thinking=True,
+        ... )
+        >>> ctx = ExecutionContext(session=session, input="Solve this step by step: 15 * 23")
+        >>> result = await llm_thinking.execute(ctx)
+    """
+
+    node_type: ClassVar[str] = "glm"
+
+    # GLM-specific options
+    thinking: bool = False  # Enable thinking/reasoning mode
+
+    @classmethod
+    def _get_default_base_url(cls) -> str:
+        """Return Z.AI GLM's default API URL."""
+        return "https://api.z.ai/api/coding/paas/v4"
+
+    def _get_extra_headers(self) -> dict[str, str]:
+        """Return Nerve-identifying headers for GLM API requests."""
+        return _load_env_and_get_headers().copy()
+
+    def _get_default_request_params(self) -> dict[str, Any]:
+        """Return GLM-specific default parameters."""
+        params: dict[str, Any] = {}
+        if self.thinking:
+            params["thinking"] = {"type": "enabled"}
+        return params

--- a/src/nerve/core/nodes/llm/openrouter.py
+++ b/src/nerve/core/nodes/llm/openrouter.py
@@ -1,0 +1,105 @@
+"""OpenRouterNode - ephemeral node for OpenRouter LLM API calls.
+
+OpenRouterNode makes HTTP requests to OpenRouter's API and returns structured results.
+Each execution is independent - no state is maintained between calls.
+
+Key features:
+- Returns structured JSON with content/usage/error fields
+- Errors are caught and returned in JSON (never raises)
+- Built-in retry with exponential backoff for transient failures
+- Supports string, messages array, or dict input formats
+- Optional request/response logging to files
+- Auto-registers with session on creation
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+from nerve.core.nodes.llm.base import SingleShotLLMNode
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass(repr=False)
+class OpenRouterNode(SingleShotLLMNode):
+    """Ephemeral node for OpenRouter LLM API calls.
+
+    OpenRouterNode is stateless - each execute() call makes an independent HTTP request.
+    Returns structured dict with response content or error (never raises).
+
+    Features:
+    - Returns structured JSON with content/model/usage/error fields
+    - Errors are caught and returned in JSON (never raises exceptions)
+    - Built-in retry with exponential backoff for 429, 5xx errors
+    - Configurable timeout, model, and API parameters
+    - Auto-registers with session on creation
+
+    Args:
+        id: Unique identifier for this node.
+        session: Session to register this node with.
+        api_key: OpenRouter API key.
+        model: Model identifier (e.g., "anthropic/claude-3-opus").
+        base_url: API base URL (default: https://openrouter.ai/api/v1).
+        timeout: Request timeout in seconds.
+        max_retries: Maximum retry attempts for retryable errors.
+        retry_base_delay: Base delay between retries in seconds.
+        retry_max_delay: Maximum delay between retries in seconds.
+        http_referer: Optional HTTP-Referer header for OpenRouter rankings.
+        x_title: Optional X-Title header for OpenRouter rankings.
+        metadata: Additional metadata for the node.
+
+    Example:
+        >>> session = Session("my-session")
+        >>> llm = OpenRouterNode(
+        ...     id="llm",
+        ...     session=session,
+        ...     api_key="sk-or-...",
+        ...     model="anthropic/claude-3-haiku",
+        ... )
+        >>>
+        >>> # Simple string prompt
+        >>> ctx = ExecutionContext(session=session, input="What is 2+2?")
+        >>> result = await llm.execute(ctx)
+        >>> print(result)
+        {
+            "success": True,
+            "content": "2 + 2 equals 4.",
+            "model": "anthropic/claude-3-haiku",
+            "finish_reason": "stop",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18},
+            "request": {"model": "anthropic/claude-3-haiku", "messages": [...]},
+            "error": None,
+            "error_type": None,
+            "retries": 0
+        }
+        >>>
+        >>> # Messages array input
+        >>> ctx = ExecutionContext(session=session, input=[
+        ...     {"role": "system", "content": "You are helpful."},
+        ...     {"role": "user", "content": "Hello!"},
+        ... ])
+        >>> result = await llm.execute(ctx)
+    """
+
+    node_type: ClassVar[str] = "openrouter"
+
+    # OpenRouter-specific optional headers
+    http_referer: str | None = None
+    x_title: str | None = None
+
+    @classmethod
+    def _get_default_base_url(cls) -> str:
+        """Return OpenRouter's default API URL."""
+        return "https://openrouter.ai/api/v1"
+
+    def _get_extra_headers(self) -> dict[str, str]:
+        """Return OpenRouter-specific headers for rankings."""
+        headers: dict[str, str] = {}
+        if self.http_referer:
+            headers["HTTP-Referer"] = self.http_referer
+        if self.x_title:
+            headers["X-Title"] = self.x_title
+        return headers

--- a/src/nerve/frontends/cli/repl/core.py
+++ b/src/nerve/frontends/cli/repl/core.py
@@ -83,6 +83,7 @@ async def run_interactive(
         WezTermNode,
     )
     from nerve.core.nodes.bash import BashNode
+    from nerve.core.nodes.llm import OpenRouterNode
     from nerve.core.nodes.terminal import ClaudeWezTermNode
     from nerve.core.session import Session
 
@@ -135,6 +136,7 @@ async def run_interactive(
             "BashNode": BashNode,
             "FunctionNode": FunctionNode,
             "Graph": Graph,
+            "OpenRouterNode": OpenRouterNode,
             "PTYNode": PTYNode,
             "WezTermNode": WezTermNode,
             "ClaudeWezTermNode": ClaudeWezTermNode,

--- a/src/nerve/frontends/cli/repl/display.py
+++ b/src/nerve/frontends/cli/repl/display.py
@@ -18,7 +18,7 @@ Nerve REPL - Interactive Python environment for AI CLI orchestration
 
 Pre-loaded:
   session     - Session named 'default' (ready to use)
-  PTYNode, WezTermNode, ClaudeWezTermNode, BashNode
+  PTYNode, WezTermNode, ClaudeWezTermNode, BashNode, OpenRouterNode
   FunctionNode, Graph, ExecutionContext, ParserType
 
 Python Examples:

--- a/src/nerve/frontends/cli/repl/file_runner.py
+++ b/src/nerve/frontends/cli/repl/file_runner.py
@@ -24,6 +24,7 @@ async def run_from_file(
         WezTermNode,
     )
     from nerve.core.nodes.bash import BashNode
+    from nerve.core.nodes.llm import OpenRouterNode
     from nerve.core.nodes.terminal import ClaudeWezTermNode
     from nerve.core.session import Session
 
@@ -36,6 +37,7 @@ async def run_from_file(
         "BashNode": BashNode,
         "FunctionNode": FunctionNode,
         "Graph": Graph,
+        "OpenRouterNode": OpenRouterNode,
         "PTYNode": PTYNode,
         "WezTermNode": WezTermNode,
         "ClaudeWezTermNode": ClaudeWezTermNode,

--- a/src/nerve/server/handlers/node_interaction_handler.py
+++ b/src/nerve/server/handlers/node_interaction_handler.py
@@ -37,6 +37,36 @@ class NodeInteractionHandler:
     session_registry: SessionRegistry
     server_name: str
 
+    async def _auto_delete_if_ephemeral(self, node: object, session: object) -> bool:
+        """Auto-delete ephemeral nodes after execution.
+
+        Args:
+            node: The node that was executed.
+            session: The session containing the node.
+
+        Returns:
+            True if the node was deleted, False otherwise.
+        """
+        # Check if node is ephemeral (persistent == False)
+        if getattr(node, "persistent", True):
+            return False
+
+        node_id = getattr(node, "id", None)
+        if not node_id:
+            return False
+
+        # Delete from session
+        deleted: bool = await session.delete_node(node_id)  # type: ignore[attr-defined]
+        if deleted:
+            # Emit NODE_DELETED event
+            await self.event_sink.emit(
+                Event(
+                    type=EventType.NODE_DELETED,
+                    node_id=node_id,
+                )
+            )
+        return deleted
+
     async def run_command(self, params: dict[str, Any]) -> dict[str, Any]:
         """Run a command in a node (fire and forget).
 
@@ -124,21 +154,41 @@ class NodeInteractionHandler:
                 context = context.with_parser(parser_type)
             response = await node.execute(context)
 
-        # Emit OUTPUT_PARSED event
-        await self.event_sink.emit(
-            Event(
-                type=EventType.OUTPUT_PARSED,
-                data={
-                    "raw": response.raw,
-                    "sections": [
-                        {"type": s.type, "content": s.content, "metadata": s.metadata}
-                        for s in response.sections
-                    ],
-                    "tokens": response.tokens,
-                },
-                node_id=node_id,
+        # Handle response based on type:
+        # - Ephemeral nodes (BashNode, OpenRouterNode) return dict
+        # - Terminal nodes return ParsedResponse
+        response_data: dict[str, Any]
+        if isinstance(response, dict):
+            # Ephemeral node - response is already a dict
+            response_data = response
+
+            # Emit OUTPUT_PARSED event with dict data
+            await self.event_sink.emit(
+                Event(
+                    type=EventType.OUTPUT_PARSED,
+                    data=response_data,
+                    node_id=node_id,
+                )
             )
-        )
+        else:
+            # Terminal node - response is ParsedResponse
+            response_data = self._serialize_response(response)
+
+            # Emit OUTPUT_PARSED event
+            await self.event_sink.emit(
+                Event(
+                    type=EventType.OUTPUT_PARSED,
+                    data={
+                        "raw": response.raw,
+                        "sections": [
+                            {"type": s.type, "content": s.content, "metadata": s.metadata}
+                            for s in response.sections
+                        ],
+                        "tokens": response.tokens,
+                    },
+                    node_id=node_id,
+                )
+            )
 
         await self.event_sink.emit(
             Event(
@@ -147,7 +197,10 @@ class NodeInteractionHandler:
             )
         )
 
-        return {"response": self._serialize_response(response)}
+        # Auto-delete ephemeral nodes after execution
+        await self._auto_delete_if_ephemeral(node, session)
+
+        return {"response": response_data}
 
     async def send_interrupt(self, params: dict[str, Any]) -> dict[str, Any]:
         """Send interrupt signal to node.

--- a/src/nerve/server/handlers/python_executor.py
+++ b/src/nerve/server/handlers/python_executor.py
@@ -141,6 +141,7 @@ class PythonExecutor:
         )
         from nerve.core.nodes.bash import BashNode
         from nerve.core.nodes.graph import Graph
+        from nerve.core.nodes.llm import OpenRouterNode
         from nerve.core.nodes.terminal import (
             ClaudeWezTermNode,
             PTYNode,
@@ -154,6 +155,7 @@ class PythonExecutor:
             "BashNode": BashNode,
             "FunctionNode": FunctionNode,
             "Graph": Graph,
+            "OpenRouterNode": OpenRouterNode,
             "PTYNode": PTYNode,
             "WezTermNode": WezTermNode,
             "ClaudeWezTermNode": ClaudeWezTermNode,

--- a/src/nerve/server/protocols.py
+++ b/src/nerve/server/protocols.py
@@ -94,6 +94,10 @@ NODE_TYPE_TO_BACKEND: dict[str, str] = {
     "PTYNode": "pty",
     "WezTermNode": "wezterm",
     "ClaudeWezTermNode": "claude-wezterm",
+    "BashNode": "bash",
+    "OpenRouterNode": "openrouter",
+    "GLMNode": "glm",
+    "LLMChatNode": "llm-chat",
 }
 
 

--- a/tests/core/nodes/llm/__init__.py
+++ b/tests/core/nodes/llm/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for LLM nodes."""

--- a/tests/core/nodes/llm/test_openrouter.py
+++ b/tests/core/nodes/llm/test_openrouter.py
@@ -1,0 +1,493 @@
+"""Tests for OpenRouterNode."""
+
+import pytest
+from aioresponses import aioresponses
+
+from nerve.core.nodes import ExecutionContext, NodeState
+from nerve.core.nodes.llm import OpenRouterNode
+from nerve.core.session import Session
+
+
+@pytest.fixture
+def session():
+    """Create a test session."""
+    return Session(name="test-session")
+
+
+@pytest.fixture
+def openrouter_node(session):
+    """Create an OpenRouterNode for testing."""
+    return OpenRouterNode(
+        id="test-llm",
+        session=session,
+        api_key="test-api-key",
+        model="anthropic/claude-3-haiku",
+        timeout=5.0,
+        max_retries=2,
+        retry_base_delay=0.1,  # Fast retries for tests
+    )
+
+
+def make_success_response(content: str = "Hello!", model: str = "anthropic/claude-3-haiku"):
+    """Create a mock successful response."""
+    return {
+        "id": "gen-test123",
+        "object": "chat.completion",
+        "created": 1234567890,
+        "model": model,
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+
+def make_error_response(message: str = "Invalid request"):
+    """Create a mock error response."""
+    return {"error": {"message": message, "type": "invalid_request_error"}}
+
+
+class TestOpenRouterNodeBasic:
+    """Basic execution tests."""
+
+    @pytest.mark.asyncio
+    async def test_string_input(self, session, openrouter_node):
+        """Test simple string prompt."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response("2 + 2 equals 4."),
+            )
+
+            context = ExecutionContext(session=session, input="What is 2+2?")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is True
+            assert result["content"] == "2 + 2 equals 4."
+            assert result["model"] == "anthropic/claude-3-haiku"
+            assert result["finish_reason"] == "stop"
+            assert result["error"] is None
+            assert result["retries"] == 0
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_messages_list_input(self, session, openrouter_node):
+        """Test messages array input."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response("Hello there!"),
+            )
+
+            context = ExecutionContext(
+                session=session,
+                input=[
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hi!"},
+                ],
+            )
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is True
+            assert result["content"] == "Hello there!"
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_dict_input_with_options(self, session, openrouter_node):
+        """Test dict input with messages and extra params."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(
+                session=session,
+                input={
+                    "messages": [{"role": "user", "content": "Test"}],
+                    "temperature": 0.5,
+                    "max_tokens": 100,
+                },
+            )
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is True
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, session, openrouter_node):
+        """Test handling of empty input."""
+        context = ExecutionContext(session=session, input=None)
+        result = await openrouter_node.execute(context)
+
+        assert result["success"] is False
+        assert "No messages provided" in result["error"]
+        assert result["error_type"] == "invalid_request_error"
+
+        await openrouter_node.close()
+
+
+class TestOpenRouterNodeResponses:
+    """Response parsing tests."""
+
+    @pytest.mark.asyncio
+    async def test_usage_parsing(self, session, openrouter_node):
+        """Test token usage is extracted."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["usage"] is not None
+            assert result["usage"]["prompt_tokens"] == 10
+            assert result["usage"]["completion_tokens"] == 5
+            assert result["usage"]["total_tokens"] == 15
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_request_echo(self, session, openrouter_node):
+        """Test request info is echoed back."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=session, input="Hello!")
+            result = await openrouter_node.execute(context)
+
+            assert result["request"]["model"] == "anthropic/claude-3-haiku"
+            assert len(result["request"]["messages"]) == 1
+
+        await openrouter_node.close()
+
+
+class TestOpenRouterNodeErrors:
+    """Error handling tests."""
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self, session, openrouter_node):
+        """Test 401 response handling."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=401,
+                payload=make_error_response("Invalid API key"),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is False
+            assert "401" in result["error"]
+            assert result["error_type"] == "authentication_error"
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_invalid_request_error(self, session, openrouter_node):
+        """Test 400 response handling."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=400,
+                payload=make_error_response("Invalid model"),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is False
+            assert result["error_type"] == "invalid_request_error"
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_exhausts_retries(self, session, openrouter_node):
+        """Test 429 response triggers retries and eventually fails."""
+        with aioresponses() as m:
+            # Return 429 three times (initial + 2 retries)
+            for _ in range(3):
+                m.post(
+                    "https://openrouter.ai/api/v1/chat/completions",
+                    status=429,
+                    payload=make_error_response("Rate limited"),
+                )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is False
+            assert result["error_type"] == "rate_limit_error"
+            assert result["retries"] == 2  # max_retries
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_server_error(self, session, openrouter_node):
+        """Test 500 response handling."""
+        with aioresponses() as m:
+            # Return 500 three times
+            for _ in range(3):
+                m.post(
+                    "https://openrouter.ai/api/v1/chat/completions",
+                    status=500,
+                    payload=make_error_response("Internal server error"),
+                )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is False
+            assert result["error_type"] == "api_error"
+
+        await openrouter_node.close()
+
+
+class TestOpenRouterNodeRetry:
+    """Retry logic tests."""
+
+    @pytest.mark.asyncio
+    async def test_retry_on_429_succeeds(self, session, openrouter_node):
+        """Test that 429 triggers retry and eventually succeeds."""
+        with aioresponses() as m:
+            # First two requests return 429, third succeeds
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=429,
+                payload=make_error_response("Rate limited"),
+            )
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=429,
+                payload=make_error_response("Rate limited"),
+            )
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response("Success after retry!"),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is True
+            assert result["content"] == "Success after retry!"
+            assert result["retries"] == 2
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_retry_on_500_succeeds(self, session, openrouter_node):
+        """Test that 500 triggers retry and eventually succeeds."""
+        with aioresponses() as m:
+            # First request returns 500, second succeeds
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=500,
+                payload=make_error_response("Server error"),
+            )
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response("Success!"),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is True
+            assert result["retries"] == 1
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_400(self, session, openrouter_node):
+        """Test that 400 does not trigger retry."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                status=400,
+                payload=make_error_response("Bad request"),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await openrouter_node.execute(context)
+
+            assert result["success"] is False
+            assert result["retries"] == 0  # No retries for 400
+
+        await openrouter_node.close()
+
+
+class TestOpenRouterNodeInfo:
+    """Node info tests."""
+
+    def test_to_info(self, openrouter_node):
+        """Test to_info returns correct NodeInfo."""
+        info = openrouter_node.to_info()
+
+        assert info.id == "test-llm"
+        assert info.node_type == "openrouter"
+        assert info.state == NodeState.READY
+        assert info.persistent is False
+        assert info.metadata["model"] == "anthropic/claude-3-haiku"
+        assert info.metadata["timeout"] == 5.0
+
+    def test_metadata_included(self, session):
+        """Test custom metadata is included."""
+        node = OpenRouterNode(
+            id="test-meta",
+            session=session,
+            api_key="key",
+            model="model",
+            metadata={"custom": "value"},
+        )
+        info = node.to_info()
+
+        assert info.metadata["custom"] == "value"
+
+    def test_persistent_is_false(self, openrouter_node):
+        """Test that persistent property is False."""
+        assert openrouter_node.persistent is False
+
+    def test_repr(self, openrouter_node):
+        """Test __repr__ returns expected format."""
+        assert (
+            repr(openrouter_node)
+            == "OpenRouterNode(id='test-llm', model='anthropic/claude-3-haiku')"
+        )
+
+
+class TestOpenRouterNodeValidation:
+    """Validation tests."""
+
+    def test_duplicate_id_raises(self, session):
+        """Test that duplicate ID raises ValueError."""
+        OpenRouterNode(id="node1", session=session, api_key="key", model="model")
+
+        with pytest.raises(ValueError, match="already exists"):
+            OpenRouterNode(id="node1", session=session, api_key="key", model="model")
+
+    def test_invalid_id_raises(self, session):
+        """Test that invalid ID raises ValueError."""
+        with pytest.raises(ValueError):
+            OpenRouterNode(id="INVALID_ID!", session=session, api_key="key", model="model")
+
+    def test_registers_with_session(self, session):
+        """Test that node is registered with session."""
+        node = OpenRouterNode(id="registered", session=session, api_key="key", model="model")
+        assert "registered" in session.nodes
+        assert session.nodes["registered"] is node
+
+
+class TestOpenRouterNodeSession:
+    """HTTP session management tests."""
+
+    @pytest.mark.asyncio
+    async def test_session_created_lazily(self, openrouter_node):
+        """Test that HTTP session is created on first request."""
+        assert openrouter_node._session_holder is None
+
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=openrouter_node.session, input="Test")
+            await openrouter_node.execute(context)
+
+            assert openrouter_node._session_holder is not None
+
+        await openrouter_node.close()
+
+    @pytest.mark.asyncio
+    async def test_close_cleans_up_session(self, openrouter_node):
+        """Test that close() releases HTTP session."""
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=openrouter_node.session, input="Test")
+            await openrouter_node.execute(context)
+
+        await openrouter_node.close()
+        assert openrouter_node._session_holder is None
+
+    @pytest.mark.asyncio
+    async def test_interrupt_is_noop(self, openrouter_node):
+        """Test that interrupt() does nothing (HTTP can't be interrupted)."""
+        # Should not raise
+        await openrouter_node.interrupt()
+
+
+class TestOpenRouterNodeCustomConfig:
+    """Custom configuration tests."""
+
+    @pytest.mark.asyncio
+    async def test_custom_base_url(self, session):
+        """Test custom base URL is used."""
+        node = OpenRouterNode(
+            id="custom-url",
+            session=session,
+            api_key="key",
+            model="model",
+            base_url="https://custom.api.com/v1",
+        )
+
+        with aioresponses() as m:
+            m.post(
+                "https://custom.api.com/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await node.execute(context)
+
+            assert result["success"] is True
+
+        await node.close()
+
+    @pytest.mark.asyncio
+    async def test_optional_headers(self, session):
+        """Test optional HTTP-Referer and X-Title headers."""
+        node = OpenRouterNode(
+            id="with-headers",
+            session=session,
+            api_key="key",
+            model="model",
+            http_referer="https://mysite.com",
+            x_title="My App",
+        )
+
+        with aioresponses() as m:
+            m.post(
+                "https://openrouter.ai/api/v1/chat/completions",
+                payload=make_success_response(),
+            )
+
+            context = ExecutionContext(session=session, input="Test")
+            result = await node.execute(context)
+
+            assert result["success"] is True
+
+        await node.close()

--- a/uv.lock
+++ b/uv.lock
@@ -297,6 +297,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +492,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/9d/e0660989c1370e25848bb4c52d061c71837239738ad937e83edca174c273/jiter-0.12.0.tar.gz", hash = "sha256:64dfcd7d5c168b38d3f9f8bba7fc639edb3418abcc74f22fdbe6b8938293f30b", size = 168294, upload-time = "2025-11-09T20:49:23.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/c9/5b9f7b4983f1b542c64e84165075335e8a236fa9e2ea03a0c79780062be8/jiter-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:305e061fa82f4680607a775b2e8e0bcb071cd2205ac38e6ef48c8dd5ebe1cf37", size = 314449, upload-time = "2025-11-09T20:47:22.999Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6e/e8efa0e78de00db0aee82c0cf9e8b3f2027efd7f8a71f859d8f4be8e98ef/jiter-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5c1860627048e302a528333c9307c818c547f214d8659b0705d2195e1a94b274", size = 319855, upload-time = "2025-11-09T20:47:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/20/26/894cd88e60b5d58af53bec5c6759d1292bd0b37a8b5f60f07abf7a63ae5f/jiter-0.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df37577a4f8408f7e0ec3205d2a8f87672af8f17008358063a4d6425b6081ce3", size = 350171, upload-time = "2025-11-09T20:47:26.469Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/27/a7b818b9979ac31b3763d25f3653ec3a954044d5e9f5d87f2f247d679fd1/jiter-0.12.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:75fdd787356c1c13a4f40b43c2156276ef7a71eb487d98472476476d803fb2cf", size = 365590, upload-time = "2025-11-09T20:47:27.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7e/e46195801a97673a83746170b17984aa8ac4a455746354516d02ca5541b4/jiter-0.12.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1eb5db8d9c65b112aacf14fcd0faae9913d07a8afea5ed06ccdd12b724e966a1", size = 479462, upload-time = "2025-11-09T20:47:29.654Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/75/f833bfb009ab4bd11b1c9406d333e3b4357709ed0570bb48c7c06d78c7dd/jiter-0.12.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:73c568cc27c473f82480abc15d1301adf333a7ea4f2e813d6a2c7d8b6ba8d0df", size = 378983, upload-time = "2025-11-09T20:47:31.026Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b3/7a69d77943cc837d30165643db753471aff5df39692d598da880a6e51c24/jiter-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4321e8a3d868919bcb1abb1db550d41f2b5b326f72df29e53b2df8b006eb9403", size = 361328, upload-time = "2025-11-09T20:47:33.286Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ac/a78f90caf48d65ba70d8c6efc6f23150bc39dc3389d65bbec2a95c7bc628/jiter-0.12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a51bad79f8cc9cac2b4b705039f814049142e0050f30d91695a2d9a6611f126", size = 386740, upload-time = "2025-11-09T20:47:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b6/5d31c2cc8e1b6a6bcf3c5721e4ca0a3633d1ab4754b09bc7084f6c4f5327/jiter-0.12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2a67b678f6a5f1dd6c36d642d7db83e456bc8b104788262aaefc11a22339f5a9", size = 520875, upload-time = "2025-11-09T20:47:36.058Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b5/4df540fae4e9f68c54b8dab004bd8c943a752f0b00efd6e7d64aa3850339/jiter-0.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efe1a211fe1fd14762adea941e3cfd6c611a136e28da6c39272dbb7a1bbe6a86", size = 511457, upload-time = "2025-11-09T20:47:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/07/65/86b74010e450a1a77b2c1aabb91d4a91dd3cd5afce99f34d75fd1ac64b19/jiter-0.12.0-cp312-cp312-win32.whl", hash = "sha256:d779d97c834b4278276ec703dc3fc1735fca50af63eb7262f05bdb4e62203d44", size = 204546, upload-time = "2025-11-09T20:47:40.47Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/6659f537f9562d963488e3e55573498a442503ced01f7e169e96a6110383/jiter-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e8269062060212b373316fe69236096aaf4c49022d267c6736eebd66bbbc60bb", size = 205196, upload-time = "2025-11-09T20:47:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f4/935304f5169edadfec7f9c01eacbce4c90bb9a82035ac1de1f3bd2d40be6/jiter-0.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:06cb970936c65de926d648af0ed3d21857f026b1cf5525cb2947aa5e01e05789", size = 186100, upload-time = "2025-11-09T20:47:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a6/97209693b177716e22576ee1161674d1d58029eb178e01866a0422b69224/jiter-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6cc49d5130a14b732e0612bc76ae8db3b49898732223ef8b7599aa8d9810683e", size = 313658, upload-time = "2025-11-09T20:47:44.424Z" },
+    { url = "https://files.pythonhosted.org/packages/06/4d/125c5c1537c7d8ee73ad3d530a442d6c619714b95027143f1b61c0b4dfe0/jiter-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:37f27a32ce36364d2fa4f7fdc507279db604d27d239ea2e044c8f148410defe1", size = 318605, upload-time = "2025-11-09T20:47:45.973Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bf/a840b89847885064c41a5f52de6e312e91fa84a520848ee56c97e4fa0205/jiter-0.12.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbc0944aa3d4b4773e348cda635252824a78f4ba44328e042ef1ff3f6080d1cf", size = 349803, upload-time = "2025-11-09T20:47:47.535Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/88/e63441c28e0db50e305ae23e19c1d8fae012d78ed55365da392c1f34b09c/jiter-0.12.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:da25c62d4ee1ffbacb97fac6dfe4dcd6759ebdc9015991e92a6eae5816287f44", size = 365120, upload-time = "2025-11-09T20:47:49.284Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7c/49b02714af4343970eb8aca63396bc1c82fa01197dbb1e9b0d274b550d4e/jiter-0.12.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:048485c654b838140b007390b8182ba9774621103bd4d77c9c3f6f117474ba45", size = 479918, upload-time = "2025-11-09T20:47:50.807Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ba/0a809817fdd5a1db80490b9150645f3aae16afad166960bcd562be194f3b/jiter-0.12.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:635e737fbb7315bef0037c19b88b799143d2d7d3507e61a76751025226b3ac87", size = 379008, upload-time = "2025-11-09T20:47:52.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/c9fc0232e736c8877d9e6d83d6eeb0ba4e90c6c073835cc2e8f73fdeef51/jiter-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e017c417b1ebda911bd13b1e40612704b1f5420e30695112efdbed8a4b389ed", size = 361785, upload-time = "2025-11-09T20:47:53.512Z" },
+    { url = "https://files.pythonhosted.org/packages/96/61/61f69b7e442e97ca6cd53086ddc1cf59fb830549bc72c0a293713a60c525/jiter-0.12.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:89b0bfb8b2bf2351fba36bb211ef8bfceba73ef58e7f0c68fb67b5a2795ca2f9", size = 386108, upload-time = "2025-11-09T20:47:54.893Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/2e/76bb3332f28550c8f1eba3bf6e5efe211efda0ddbbaf24976bc7078d42a5/jiter-0.12.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:f5aa5427a629a824a543672778c9ce0c5e556550d1569bb6ea28a85015287626", size = 519937, upload-time = "2025-11-09T20:47:56.253Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d6/fa96efa87dc8bff2094fb947f51f66368fa56d8d4fc9e77b25d7fbb23375/jiter-0.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed53b3d6acbcb0fd0b90f20c7cb3b24c357fe82a3518934d4edfa8c6898e498c", size = 510853, upload-time = "2025-11-09T20:47:58.32Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/28/93f67fdb4d5904a708119a6ab58a8f1ec226ff10a94a282e0215402a8462/jiter-0.12.0-cp313-cp313-win32.whl", hash = "sha256:4747de73d6b8c78f2e253a2787930f4fffc68da7fa319739f57437f95963c4de", size = 204699, upload-time = "2025-11-09T20:47:59.686Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/1f/30b0eb087045a0abe2a5c9c0c0c8da110875a1d3be83afd4a9a4e548be3c/jiter-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e25012eb0c456fcc13354255d0338cd5397cce26c77b2832b3c4e2e255ea5d9a", size = 204258, upload-time = "2025-11-09T20:48:01.01Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f4/2b4daf99b96bce6fc47971890b14b2a36aef88d7beb9f057fafa032c6141/jiter-0.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:c97b92c54fe6110138c872add030a1f99aea2401ddcdaa21edf74705a646dd60", size = 185503, upload-time = "2025-11-09T20:48:02.35Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/67bb15a7061d6fe20b9b2a2fd783e296a1e0f93468252c093481a2f00efa/jiter-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:53839b35a38f56b8be26a7851a48b89bc47e5d88e900929df10ed93b95fea3d6", size = 317965, upload-time = "2025-11-09T20:48:03.783Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/1788031cd22e29c3b14bc6ca80b16a39a0b10e611367ffd480c06a259831/jiter-0.12.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f669548e55c91ab47fef8bddd9c954dab1938644e715ea49d7e117015110a4", size = 345831, upload-time = "2025-11-09T20:48:05.55Z" },
+    { url = "https://files.pythonhosted.org/packages/05/17/710bf8472d1dff0d3caf4ced6031060091c1320f84ee7d5dcbed1f352417/jiter-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:351d54f2b09a41600ffea43d081522d792e81dcfb915f6d2d242744c1cc48beb", size = 361272, upload-time = "2025-11-09T20:48:06.951Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/1dcc4618b59761fef92d10bcbb0b038b5160be653b003651566a185f1a5c/jiter-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2a5e90604620f94bf62264e7c2c038704d38217b7465b863896c6d7c902b06c7", size = 204604, upload-time = "2025-11-09T20:48:08.328Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/32/63cb1d9f1c5c6632a783c0052cde9ef7ba82688f7065e2f0d5f10a7e3edb/jiter-0.12.0-cp313-cp313t-win_arm64.whl", hash = "sha256:88ef757017e78d2860f96250f9393b7b577b06a956ad102c29c8237554380db3", size = 185628, upload-time = "2025-11-09T20:48:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/45c9f0dbe4a1416b2b9a8a6d1236459540f43d7fb8883cff769a8db0612d/jiter-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c46d927acd09c67a9fb1416df45c5a04c27e83aae969267e98fba35b74e99525", size = 312478, upload-time = "2025-11-09T20:48:10.898Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a7/54ae75613ba9e0f55fcb0bc5d1f807823b5167cc944e9333ff322e9f07dd/jiter-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:774ff60b27a84a85b27b88cd5583899c59940bcc126caca97eb2a9df6aa00c49", size = 318706, upload-time = "2025-11-09T20:48:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/2aa241ad2c10774baf6c37f8b8e1f39c07db358f1329f4eb40eba179c2a2/jiter-0.12.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c5433fab222fb072237df3f637d01b81f040a07dcac1cb4a5c75c7aa9ed0bef1", size = 351894, upload-time = "2025-11-09T20:48:13.673Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4f/0f2759522719133a9042781b18cc94e335b6d290f5e2d3e6899d6af933e3/jiter-0.12.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f8c593c6e71c07866ec6bfb790e202a833eeec885022296aff6b9e0b92d6a70e", size = 365714, upload-time = "2025-11-09T20:48:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/6f/806b895f476582c62a2f52c453151edd8a0fde5411b0497baaa41018e878/jiter-0.12.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:90d32894d4c6877a87ae00c6b915b609406819dce8bc0d4e962e4de2784e567e", size = 478989, upload-time = "2025-11-09T20:48:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6c/012d894dc6e1033acd8db2b8346add33e413ec1c7c002598915278a37f79/jiter-0.12.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:798e46eed9eb10c3adbbacbd3bdb5ecd4cf7064e453d00dbef08802dae6937ff", size = 378615, upload-time = "2025-11-09T20:48:18.614Z" },
+    { url = "https://files.pythonhosted.org/packages/87/30/d718d599f6700163e28e2c71c0bbaf6dace692e7df2592fd793ac9276717/jiter-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3f1368f0a6719ea80013a4eb90ba72e75d7ea67cfc7846db2ca504f3df0169a", size = 364745, upload-time = "2025-11-09T20:48:20.117Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/85/315b45ce4b6ddc7d7fceca24068543b02bdc8782942f4ee49d652e2cc89f/jiter-0.12.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:65f04a9d0b4406f7e51279710b27484af411896246200e461d80d3ba0caa901a", size = 386502, upload-time = "2025-11-09T20:48:21.543Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0b/ce0434fb40c5b24b368fe81b17074d2840748b4952256bab451b72290a49/jiter-0.12.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:fd990541982a24281d12b67a335e44f117e4c6cbad3c3b75c7dea68bf4ce3a67", size = 519845, upload-time = "2025-11-09T20:48:22.964Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a3/7a7a4488ba052767846b9c916d208b3ed114e3eb670ee984e4c565b9cf0d/jiter-0.12.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:b111b0e9152fa7df870ecaebb0bd30240d9f7fff1f2003bcb4ed0f519941820b", size = 510701, upload-time = "2025-11-09T20:48:24.483Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/052ffbf9d0467b70af24e30f91e0579e13ded0c17bb4a8eb2aed3cb60131/jiter-0.12.0-cp314-cp314-win32.whl", hash = "sha256:a78befb9cc0a45b5a5a0d537b06f8544c2ebb60d19d02c41ff15da28a9e22d42", size = 205029, upload-time = "2025-11-09T20:48:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/18/3cf1f3f0ccc789f76b9a754bdb7a6977e5d1d671ee97a9e14f7eb728d80e/jiter-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:e1fe01c082f6aafbe5c8faf0ff074f38dfb911d53f07ec333ca03f8f6226debf", size = 204960, upload-time = "2025-11-09T20:48:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/02/68/736821e52ecfdeeb0f024b8ab01b5a229f6b9293bbdb444c27efade50b0f/jiter-0.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:d72f3b5a432a4c546ea4bedc84cce0c3404874f1d1676260b9c7f048a9855451", size = 185529, upload-time = "2025-11-09T20:48:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/30/61/12ed8ee7a643cce29ac97c2281f9ce3956eb76b037e88d290f4ed0d41480/jiter-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e6ded41aeba3603f9728ed2b6196e4df875348ab97b28fc8afff115ed42ba7a7", size = 318974, upload-time = "2025-11-09T20:48:30.87Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c6/f3041ede6d0ed5e0e79ff0de4c8f14f401bbf196f2ef3971cdbe5fd08d1d/jiter-0.12.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a947920902420a6ada6ad51892082521978e9dd44a802663b001436e4b771684", size = 345932, upload-time = "2025-11-09T20:48:32.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5d/4d94835889edd01ad0e2dbfc05f7bdfaed46292e7b504a6ac7839aa00edb/jiter-0.12.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:add5e227e0554d3a52cf390a7635edaffdf4f8fce4fdbcef3cc2055bb396a30c", size = 367243, upload-time = "2025-11-09T20:48:34.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/76/0051b0ac2816253a99d27baf3dda198663aff882fa6ea7deeb94046da24e/jiter-0.12.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f9b1cda8fcb736250d7e8711d4580ebf004a46771432be0ae4796944b5dfa5d", size = 479315, upload-time = "2025-11-09T20:48:35.507Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/83f793acd68e5cb24e483f44f482a1a15601848b9b6f199dacb970098f77/jiter-0.12.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:deeb12a2223fe0135c7ff1356a143d57f95bbf1f4a66584f1fc74df21d86b993", size = 380714, upload-time = "2025-11-09T20:48:40.014Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/4808a88338ad2c228b1126b93fcd8ba145e919e886fe910d578230dabe3b/jiter-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c596cc0f4cb574877550ce4ecd51f8037469146addd676d7c1a30ebe6391923f", size = 365168, upload-time = "2025-11-09T20:48:41.462Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d4/04619a9e8095b42aef436b5aeb4c0282b4ff1b27d1db1508df9f5dc82750/jiter-0.12.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ab4c823b216a4aeab3fdbf579c5843165756bd9ad87cc6b1c65919c4715f783", size = 387893, upload-time = "2025-11-09T20:48:42.921Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ea/d3c7e62e4546fdc39197fa4a4315a563a89b95b6d54c0d25373842a59cbe/jiter-0.12.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e427eee51149edf962203ff8db75a7514ab89be5cb623fb9cea1f20b54f1107b", size = 520828, upload-time = "2025-11-09T20:48:44.278Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0b/c6d3562a03fd767e31cb119d9041ea7958c3c80cb3d753eafb19b3b18349/jiter-0.12.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:edb868841f84c111255ba5e80339d386d937ec1fdce419518ce1bd9370fac5b6", size = 511009, upload-time = "2025-11-09T20:48:45.726Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/51/2cb4468b3448a8385ebcd15059d325c9ce67df4e2758d133ab9442b19834/jiter-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8bbcfe2791dfdb7c5e48baf646d37a6a3dcb5a97a032017741dea9f817dca183", size = 205110, upload-time = "2025-11-09T20:48:47.033Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c5/ae5ec83dec9c2d1af805fd5fe8f74ebded9c8670c5210ec7820ce0dbeb1e/jiter-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2fa940963bf02e1d8226027ef461e36af472dea85d36054ff835aeed944dd873", size = 205223, upload-time = "2025-11-09T20:48:49.076Z" },
+    { url = "https://files.pythonhosted.org/packages/97/9a/3c5391907277f0e55195550cf3fa8e293ae9ee0c00fb402fec1e38c0c82f/jiter-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:506c9708dd29b27288f9f8f1140c3cb0e3d8ddb045956d7757b1fa0e0f39a473", size = 185564, upload-time = "2025-11-09T20:48:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/f5/12efb8ada5f5c9edc1d4555fe383c1fb2eac05ac5859258a72d61981d999/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:e8547883d7b96ef2e5fe22b88f8a4c8725a56e7f4abafff20fd5272d634c7ecb", size = 309974, upload-time = "2025-11-09T20:49:17.187Z" },
+    { url = "https://files.pythonhosted.org/packages/85/15/d6eb3b770f6a0d332675141ab3962fd4a7c270ede3515d9f3583e1d28276/jiter-0.12.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:89163163c0934854a668ed783a2546a0617f71706a2551a4a0666d91ab365d6b", size = 304233, upload-time = "2025-11-09T20:49:18.734Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/3e/e7e06743294eea2cf02ced6aa0ff2ad237367394e37a0e2b4a1108c67a36/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d96b264ab7d34bbb2312dedc47ce07cd53f06835eacbc16dde3761f47c3a9e7f", size = 338537, upload-time = "2025-11-09T20:49:20.317Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/9c/6753e6522b8d0ef07d3a3d239426669e984fb0eba15a315cdbc1253904e4/jiter-0.12.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24e864cb30ab82311c6425655b0cdab0a98c5d973b065c66a3f020740c2324c", size = 346110, upload-time = "2025-11-09T20:49:21.817Z" },
 ]
 
 [[package]]
@@ -757,7 +834,9 @@ source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "httpx", extra = ["http2"] },
+    { name = "openai" },
     { name = "prompt-toolkit" },
+    { name = "python-dotenv" },
     { name = "rich-click" },
 ]
 
@@ -797,6 +876,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'all'", specifier = ">=1.8.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "openai", specifier = ">=1.0.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", marker = "extra == 'all'", specifier = ">=2.0" },
     { name = "pydantic", marker = "extra == 'gateway'", specifier = ">=2.0" },
@@ -804,6 +884,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.23.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", marker = "extra == 'all'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'gateway'", specifier = ">=6.0" },
     { name = "rich-click", specifier = ">=1.7.0" },
@@ -811,6 +892,25 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
 ]
 provides-extras = ["all", "dev", "gateway", "mcp"]
+
+[[package]]
+name = "openai"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/b1/12fe1c196bea326261718eb037307c1c1fe1dedc2d2d4de777df822e6238/openai-2.14.0.tar.gz", hash = "sha256:419357bedde9402d23bf8f2ee372fca1985a73348debba94bddff06f19459952", size = 626938, upload-time = "2025-12-19T03:28:45.742Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/4b/7c1a00c2c3fbd004253937f7520f692a9650767aa73894d7a34f0d65d3f4/openai-2.14.0-py3-none-any.whl", hash = "sha256:7ea40aca4ffc4c4a776e77679021b47eec1160e341f42ae086ba949c9dcc9183", size = 1067558, upload-time = "2025-12-19T03:28:43.727Z" },
+]
 
 [[package]]
 name = "packaging"
@@ -1325,6 +1425,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1348,6 +1457,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- introduce OpenRouterNode and GLMNode as stateless nodes for direct LLM API integration via OpenRouter or Z.AI GLM
- implement SingleShotLLMNode as an abstract base for OpenAI-compatible LLM calls with structured results, retries, and error handling
- add LLMChatNode for persistent, multi-turn conversations with optional tool support, using any SingleShotLLMNode
- support LLM nodes in CLI, server node creation, and node factory with options for API keys, models, http backend, debug logging, and 'thinking' mode (GLM)
- enable ephemeral node behavior—BashNode, OpenRouterNode, and GLMNode are auto-deleted after execution
- update CLI, server, and PythonExecutor to expose new LLM node types and options
- add protocol and handler support for ephemeral LLM nodes including correct lifecycle management
- include comprehensive tests for OpenRouterNode covering request/response handling, retries, and error scenarios
- minor: add .env loading for feature tests and set exclusions for features/ in ruff/mypy configs
- briefly updated docs to enumerate usage and new classes without deep detail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GLM and OpenRouter LLM provider nodes for single-shot API calls
  * Added chat node supporting multi-turn conversations with system prompts and tool execution
  * Added bash node for ephemeral shell command execution
  * Integrated new node types into REPL and server interfaces

* **Tests**
  * Added feature test suites for GLM and OpenRouter providers with API integration tests

* **Chores**
  * Added openai and python-dotenv dependencies
  * Added .env.local configuration file support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->