### PR TITLE
Prevent unnecessary waiting status if dependencies already complete

### DIFF
--- a/DIR_STRUCTURE.md
+++ b/DIR_STRUCTURE.md
@@ -182,7 +182,7 @@
 │       │           ├── [L: 279] blocks.py
 │       │           ├── [L: 406] commander.py
 │       │           ├── [L: 174] commands.py
-│       │           ├── [L: 357] executor.py
+│       │           ├── [L: 377] executor.py
 │       │           ├── [L: 356] loop.py
 │       │           ├── [L: 350] rendering.py
 │       │           ├── [L: 146] themes.py
@@ -278,7 +278,7 @@
     │   │   └── [L: 206] test_client.py
     │   └── tui/
     │       ├── [L:   1] __init__.py
-    │       ├── [L: 602] test_commander_dependencies.py
+    │       ├── [L: 626] test_commander_dependencies.py
     │       └── [L: 395] test_variable_expansion.py
     ├── gateway/
     │   ├── [L:   1] __init__.py
@@ -304,4 +304,4 @@
     └── transport/
         └── [L:   1] __init__.py
 
-65 directories, 240 files, 55,062 total lines
+65 directories, 240 files, 55,106 total lines

--- a/src/nerve/frontends/cli/repl/adapters.py
+++ b/src/nerve/frontends/cli/repl/adapters.py
@@ -332,7 +332,7 @@ class RemoteSessionAdapter:
     # Execution timeout constants (in seconds)
     DEFAULT_TIMEOUT = 300.0  # 5 minutes for standard nodes
     CLAUDE_NODE_TIMEOUT = 2400.0  # 40 minutes for long-running Claude tasks
-    CLAUDE_NODE_TYPES = {"ClaudeWezTermNode", "ClaudeWezTerm"}  # Node types with extended timeout
+    CLAUDE_NODE_TYPES = {"claude-wezterm"}  # Node types with extended timeout
 
     def __init__(
         self, client: Any, server_name: str, session_name: str | None = None


### PR DESCRIPTION
- Check dependency readiness before setting block status to "waiting" in CommandExecutor
- Set status to "pending" directly if all dependencies are done, avoiding unnecessary UI renders
- Update RemoteSessionAdapter to standardize CLAUDE_NODE_TYPES value to "claude-wezterm"
- Add test to verify blocks skip "waiting" status when dependencies are already completed
- Minor test and doc updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Enhanced dependency resolution with immediate pending state transition when dependencies are already satisfied
* **Chores**
  * Updated terminal session node type configuration
  * Documentation and test coverage updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->