### PR TITLE
fix(commander): ensure dependency references resolve to latest block …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .env.local
 bin/
 anthropicLogs/
+scratchpad/

--- a/DIR_STRUCTURE.md
+++ b/DIR_STRUCTURE.md
@@ -182,11 +182,11 @@
 │       │           ├── [L: 279] blocks.py
 │       │           ├── [L: 406] commander.py
 │       │           ├── [L: 174] commands.py
-│       │           ├── [L: 377] executor.py
+│       │           ├── [L: 395] executor.py
 │       │           ├── [L: 356] loop.py
 │       │           ├── [L: 350] rendering.py
 │       │           ├── [L: 146] themes.py
-│       │           └── [L: 507] variables.py
+│       │           └── [L: 519] variables.py
 │       ├── gateway/
 │       │   ├── [L:  54] __init__.py
 │       │   ├── [L: 639] anthropic_proxy.py
@@ -278,7 +278,7 @@
     │   │   └── [L: 206] test_client.py
     │   └── tui/
     │       ├── [L:   1] __init__.py
-    │       ├── [L: 626] test_commander_dependencies.py
+    │       ├── [L: 682] test_commander_dependencies.py
     │       └── [L: 395] test_variable_expansion.py
     ├── gateway/
     │   ├── [L:   1] __init__.py
@@ -304,4 +304,4 @@
     └── transport/
         └── [L:   1] __init__.py
 
-65 directories, 240 files, 55,106 total lines
+65 directories, 240 files, 55,192 total lines

--- a/src/nerve/frontends/tui/commander/variables.py
+++ b/src/nerve/frontends/tui/commander/variables.py
@@ -20,11 +20,14 @@ Expands block references in text, supporting:
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nerve.frontends.tui.commander.blocks import Block, Timeline
+
+logger = logging.getLogger(__name__)
 
 
 class VariableExpander:
@@ -502,6 +505,15 @@ def extract_block_dependencies(
 
         # Get the last block from this node
         if node_blocks:
-            dependencies.add(node_blocks[-1].number)
+            last_block_num = node_blocks[-1].number
+            dependencies.add(last_block_num)
+            # DEBUG: Show which block is being referenced
+            logger.debug(
+                ":::%s resolved to block %d (found %d blocks for node '%s', using last one)",
+                node_ref,
+                last_block_num,
+                len(node_blocks),
+                node_id,
+            )
 
     return dependencies


### PR DESCRIPTION
…at extraction time

- update dependency extraction so :::nodename always resolves to the latest block of that node at extraction time
- prevent main REPL loop from blocking by queuing dependency waits for background execution
- add debug logging for dependency resolution details
- expand tests to verify dynamic dependency chain behavior
- minor docstring and comment updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored directories configuration.
  * Updated documentation annotations for file structure.

* **Tests**
  * Added test for node reference resolution in dependency extraction.

* **Bug Fixes**
  * Improved responsiveness by processing dependent blocks asynchronously in the background instead of blocking the main interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->